### PR TITLE
fix(DST): prevent backwards time travel during DST fall-back transiti…

### DIFF
--- a/src/Quartz.Tests.Unit/DaylightSavingTimeTests.cs
+++ b/src/Quartz.Tests.Unit/DaylightSavingTimeTests.cs
@@ -1,25 +1,30 @@
 ﻿#region License
-/* 
+
+/*
  * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not 
- * use this file except in compliance with the License. You may obtain a copy 
- * of the License at 
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0 
- *   
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
- * License for the specific language governing permissions and limitations 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
  * under the License.
- * 
+ *
  */
+
 #endregion
 
 using System;
+using System.Linq;
 
 using NUnit.Framework;
+
+using Quartz.Spi;
 
 using TimeZoneConverter;
 
@@ -119,5 +124,315 @@ public class DaylightSavingTimeTest
         // Conversion here is for clarity of interpreting errors if the test fails.
         DateTimeOffset convertedFireTime = TimeZoneInfo.ConvertTime(fireTime.Value, tz);
         Assert.AreEqual(expectedTime, convertedFireTime);
+    }
+
+    [Test]
+    public void Can_GetNextFireTime_InDST_To_Issue_2475()
+    {
+        // Test starting during DST (first occurrence of 2:00 AM)
+        var tz = TZConvert.GetTimeZoneInfo("Central European Standard Time"); //UTC+1  +2 in DST
+        var startTime = new DateTimeOffset(2023, 10, 29, 2, 0, 0, TimeSpan.FromHours(2));
+
+        Assert.IsTrue(tz.IsDaylightSavingTime(startTime), "Should be in DST");
+
+        var trigger = TriggerBuilder.Create()
+            .WithIdentity("trigger1", "group1")
+            .WithSchedule(CronScheduleBuilder.CronSchedule("0 0/1 * ? * * *")
+                .InTimeZone(tz)
+            )
+            .StartAt(startTime)
+            .ForJob("job1", "group1")
+            .Build();
+
+        var nextFireTimes = TriggerUtils.ComputeFireTimes((IOperableTrigger)trigger, null, 20);
+
+        // Fire times are returned in UTC
+        // 2:00 AM CEST (UTC+2) = 00:00 UTC
+        Assert.Multiple(() =>
+        {
+            Assert.That(nextFireTimes[0], Is.EqualTo(new DateTimeOffset(2023, 10, 29, 0, 00, 0, TimeSpan.Zero)));
+            Assert.That(nextFireTimes[1], Is.EqualTo(new DateTimeOffset(2023, 10, 29, 0, 01, 0, TimeSpan.Zero)));
+            Assert.That(nextFireTimes[2], Is.EqualTo(new DateTimeOffset(2023, 10, 29, 0, 02, 0, TimeSpan.Zero)));
+
+            // Verify times advance monotonically
+            Assert.That(nextFireTimes[0].UtcDateTime, Is.GreaterThanOrEqualTo(startTime.UtcDateTime));
+        });
+    }
+
+    [Test]
+    public void Can_GetNextFireTime_Transition_To_ST_Issue_2475()
+    {
+        // Test starting during standard time (second occurrence of 2:00 AM after DST ends)
+        var tz = TZConvert.GetTimeZoneInfo("Central European Standard Time"); //UTC+1  +2 in DST
+        var startTime = new DateTimeOffset(2023, 10, 29, 2, 0, 0, TimeSpan.FromHours(1));
+
+        Assert.IsFalse(tz.IsDaylightSavingTime(startTime), "Should be in standard time");
+
+        var trigger = TriggerBuilder.Create()
+            .WithIdentity("trigger1", "group1")
+            .WithSchedule(CronScheduleBuilder.CronSchedule("0 0/1 * ? * * *")
+                .InTimeZone(tz)
+            )
+            .StartAt(startTime)
+            .ForJob("job1", "group1")
+            .Build();
+
+        var nextFireTimes = TriggerUtils.ComputeFireTimes((IOperableTrigger)trigger, null, 20);
+
+        // Fire times are returned in UTC
+        // 2:00 AM CET (UTC+1, second occurrence) = 01:00 UTC
+        // The fix ensures we don't go backwards to the first occurrence (00:00 UTC)
+        Assert.Multiple(() =>
+        {
+            Assert.That(nextFireTimes[0], Is.EqualTo(new DateTimeOffset(2023, 10, 29, 1, 00, 0, TimeSpan.Zero)));
+            Assert.That(nextFireTimes[1], Is.EqualTo(new DateTimeOffset(2023, 10, 29, 1, 01, 0, TimeSpan.Zero)));
+            Assert.That(nextFireTimes[2], Is.EqualTo(new DateTimeOffset(2023, 10, 29, 1, 02, 0, TimeSpan.Zero)));
+
+            // Critical: Verify no backwards time travel
+            Assert.That(nextFireTimes[0].UtcDateTime, Is.GreaterThanOrEqualTo(startTime.UtcDateTime),
+                "First fire time must not be before start time");
+
+            // Verify monotonic progression
+            for (int i = 1; i < 3; i++)
+            {
+                Assert.That(nextFireTimes[i], Is.GreaterThan(nextFireTimes[i - 1]),
+                    $"Fire times must advance monotonically: [{i - 1}]={nextFireTimes[i - 1]}, [{i}]={nextFireTimes[i]}");
+            }
+        });
+    }
+
+    [Test]
+    public void SpringForward_JobExecutingEveryMinute_SkipsMissingHour()
+    {
+        // March 13, 2016: 2:00 AM PST -> 3:00 AM PDT (clocks jump forward, 2:00-3:00 doesn't exist)
+        var tz = TZConvert.GetTimeZoneInfo("Pacific Standard Time");
+        var startTime = new DateTimeOffset(2016, 3, 13, 1, 58, 0, TimeSpan.FromHours(-8));
+
+        var trigger = TriggerBuilder.Create()
+            .WithIdentity("trigger1", "group1")
+            .WithSchedule(CronScheduleBuilder.CronSchedule("0 * * ? * * *") // Every minute
+                .InTimeZone(tz))
+            .StartAt(startTime)
+            .ForJob("job1", "group1")
+            .Build();
+
+        var nextFireTimes = TriggerUtils.ComputeFireTimes((IOperableTrigger)trigger, null, 10);
+
+        // Convert to local time for easier verification
+        var localTimes = nextFireTimes.Select(ft => TimeZoneInfo.ConvertTime(ft, tz)).ToList();
+
+        Assert.Multiple(() =>
+        {
+            // Should fire at 1:58, 1:59 in PST
+            Assert.That(localTimes[0].Hour, Is.EqualTo(1));
+            Assert.That(localTimes[0].Minute, Is.EqualTo(58));
+            Assert.That(localTimes[1].Hour, Is.EqualTo(1));
+            Assert.That(localTimes[1].Minute, Is.EqualTo(59));
+
+            // Should skip 2:00-2:59 (missing hour) and continue at 3:00 PDT
+            Assert.That(localTimes[2].Hour, Is.EqualTo(3));
+            Assert.That(localTimes[2].Minute, Is.EqualTo(0));
+            Assert.That(localTimes[3].Hour, Is.EqualTo(3));
+            Assert.That(localTimes[3].Minute, Is.EqualTo(1));
+
+            // Verify UTC times are monotonically increasing
+            for (int i = 1; i < nextFireTimes.Count; i++)
+            {
+                Assert.That(nextFireTimes[i].UtcDateTime, Is.GreaterThan(nextFireTimes[i - 1].UtcDateTime),
+                    $"Fire times must advance: [{i - 1}]={nextFireTimes[i - 1].UtcDateTime:HH:mm:ss}, [{i}]={nextFireTimes[i].UtcDateTime:HH:mm:ss}");
+            }
+
+            // Verify all times are on or after start time
+            Assert.That(nextFireTimes[0].UtcDateTime, Is.GreaterThanOrEqualTo(startTime.UtcDateTime));
+        });
+    }
+
+    [Test]
+    public void FallBack_JobExecutingEveryMinute_SkipsOverlappingHour()
+    {
+        // November 6, 2016: At 2:00 AM PDT, clocks fall back to 1:00 AM PST
+        // When using cron patterns based on wall-clock time (hour:minute), the overlapping hour is skipped
+        // because incrementing minute from 59 to 60 wraps to hour 2, which occurs after the transition
+        var tz = TZConvert.GetTimeZoneInfo("Pacific Standard Time");
+
+        // Start at 1:58 AM PDT (before the transition)
+        var startTime = new DateTimeOffset(2016, 11, 6, 1, 58, 0, TimeSpan.FromHours(-7));
+
+        var trigger = TriggerBuilder.Create()
+            .WithIdentity("trigger1", "group1")
+            .WithSchedule(CronScheduleBuilder.CronSchedule("0 * * ? * * *") // Every minute (wall-clock based)
+                .InTimeZone(tz))
+            .StartAt(startTime)
+            .ForJob("job1", "group1")
+            .Build();
+
+        var nextFireTimes = TriggerUtils.ComputeFireTimes((IOperableTrigger)trigger, null, 10);
+        var localTimes = nextFireTimes.Select(ft => TimeZoneInfo.ConvertTime(ft, tz)).ToList();
+
+        Assert.Multiple(() =>
+        {
+            // Should fire at:
+            // 1:58 AM PDT (08:58 UTC)
+            // 1:59 AM PDT (08:59 UTC)
+            // 2:00 AM PST (10:00 UTC) - skips the overlapping 1:xx hour because cron increments to hour 2
+            // 2:01 AM PST (10:01 UTC)
+
+            Assert.That(localTimes[0].Hour, Is.EqualTo(1));
+            Assert.That(localTimes[0].Minute, Is.EqualTo(58));
+
+            Assert.That(localTimes[1].Hour, Is.EqualTo(1));
+            Assert.That(localTimes[1].Minute, Is.EqualTo(59));
+
+            // After 1:59, cron increments to 2:00 (which is after the fall-back)
+            Assert.That(localTimes[2].Hour, Is.EqualTo(2));
+            Assert.That(localTimes[2].Minute, Is.EqualTo(0));
+
+            Assert.That(localTimes[3].Hour, Is.EqualTo(2));
+            Assert.That(localTimes[3].Minute, Is.EqualTo(1));
+
+            // Verify UTC times are strictly increasing
+            for (int i = 1; i < nextFireTimes.Count; i++)
+            {
+                Assert.That(nextFireTimes[i].UtcDateTime, Is.GreaterThan(nextFireTimes[i - 1].UtcDateTime),
+                    $"UTC times must strictly increase: [{i - 1}]={nextFireTimes[i - 1].UtcDateTime:HH:mm:ss}, [{i}]={nextFireTimes[i].UtcDateTime:HH:mm:ss}");
+            }
+
+            // Verify first fire time is on or after start time
+            Assert.That(nextFireTimes[0].UtcDateTime, Is.GreaterThanOrEqualTo(startTime.UtcDateTime));
+        });
+    }
+
+    [Test]
+    public void FallBack_JobEvery5Minutes_SkipsOverlappingHour()
+    {
+        // November 6, 2016: At 2:00 AM PDT, clocks fall back to 1:00 AM PST
+        // Cron patterns based on wall-clock time skip the overlapping hour
+        var tz = TZConvert.GetTimeZoneInfo("Pacific Standard Time");
+
+        // Start at 1:20 AM PDT (before the transition)
+        var startTime = new DateTimeOffset(2016, 11, 6, 1, 20, 0, TimeSpan.FromHours(-7));
+
+        var trigger = TriggerBuilder.Create()
+            .WithIdentity("trigger1", "group1")
+            .WithSchedule(CronScheduleBuilder.CronSchedule("0 */5 * ? * * *") // Every 5 minutes
+                .InTimeZone(tz))
+            .StartAt(startTime)
+            .ForJob("job1", "group1")
+            .Build();
+
+        var nextFireTimes = TriggerUtils.ComputeFireTimes((IOperableTrigger)trigger, null, 10);
+        var localTimes = nextFireTimes.Select(ft => TimeZoneInfo.ConvertTime(ft, tz)).ToList();
+        var utcTimes = nextFireTimes.Select(ft => ft.UtcDateTime).ToList();
+
+        Assert.Multiple(() =>
+        {
+            // Should fire at:
+            // 1:20 PDT (08:20 UTC)
+            // 1:25 PDT (08:25 UTC)
+            // 1:30 PDT (08:30 UTC)
+            // 1:35 PDT (08:35 UTC)
+            // 1:40 PDT (08:40 UTC)
+            // 1:45 PDT (08:45 UTC)
+            // 1:50 PDT (08:50 UTC)
+            // 1:55 PDT (08:55 UTC)
+            // 2:00 PST (10:00 UTC) - skips to hour 2 after transition
+            // 2:05 PST (10:05 UTC)
+
+            Assert.That(localTimes[0].Minute, Is.EqualTo(20));
+            Assert.That(localTimes[1].Minute, Is.EqualTo(25));
+            Assert.That(localTimes[7].Hour, Is.EqualTo(1));
+            Assert.That(localTimes[7].Minute, Is.EqualTo(55));
+
+            // After 1:55, next 5-minute mark is 2:00 (post-transition)
+            Assert.That(localTimes[8].Hour, Is.EqualTo(2));
+            Assert.That(localTimes[8].Minute, Is.EqualTo(0));
+
+            // Verify all UTC times increase monotonically
+            for (int i = 1; i < utcTimes.Count; i++)
+            {
+                Assert.That(utcTimes[i], Is.GreaterThan(utcTimes[i - 1]),
+                    $"UTC time must increase: [{i - 1}]={utcTimes[i - 1]:HH:mm:ss} -> [{i}]={utcTimes[i]:HH:mm:ss}");
+            }
+
+            // Verify 5-minute intervals in UTC (except across the transition)
+            for (int i = 1; i < 8; i++) // Before transition
+            {
+                var diff = (utcTimes[i] - utcTimes[i - 1]).TotalMinutes;
+                Assert.That(diff, Is.EqualTo(5.0).Within(0.001),
+                    $"Should be 5 minutes apart: [{i - 1}]={utcTimes[i - 1]:HH:mm:ss} -> [{i}]={utcTimes[i]:HH:mm:ss}");
+            }
+
+            // Across transition: 1:55 PDT (08:55 UTC) -> 2:00 PST (10:00 UTC) = 65 minutes
+            var transitionDiff = (utcTimes[8] - utcTimes[7]).TotalMinutes;
+            Assert.That(transitionDiff, Is.EqualTo(65.0).Within(0.001),
+                "Transition from 1:55 PDT to 2:00 PST skips the overlapping hour");
+        });
+    }
+
+    [Test]
+    public void SpringForward_JobScheduledInMissingHour_AdvancesToNextValidTime()
+    {
+        // March 13, 2016: At 2:00 AM, clocks spring forward to 3:00 AM
+        var tz = TZConvert.GetTimeZoneInfo("Pacific Standard Time");
+
+        // Schedule job for 2:15 AM, which doesn't exist
+        var trigger = TriggerBuilder.Create()
+            .WithIdentity("trigger1", "group1")
+            .WithSchedule(CronScheduleBuilder.CronSchedule("0 15 2 ? * * *") // 2:15 AM daily
+                .InTimeZone(tz))
+            .ForJob("job1", "group1")
+            .Build();
+
+        var midnight = new DateTimeOffset(2016, 3, 13, 0, 0, 0, TimeSpan.FromHours(-8));
+        var fireTime = trigger.GetFireTimeAfter(midnight);
+
+        Assert.That(fireTime, Is.Not.Null);
+
+        var localTime = TimeZoneInfo.ConvertTime(fireTime.Value, tz);
+
+        // Since 2:15 AM doesn't exist, it should advance to 3:15 AM PDT
+        Assert.Multiple(() =>
+        {
+            Assert.That(localTime.Hour, Is.EqualTo(3));
+            Assert.That(localTime.Minute, Is.EqualTo(15));
+            Assert.That(localTime.Offset, Is.EqualTo(TimeSpan.FromHours(-7)), "Should be in PDT (UTC-7)");
+        });
+    }
+
+    [Test]
+    public void FallBack_CronEverySecond_MaintainsMonotonicProgression()
+    {
+        // October 29, 2023: 3:00 AM CEST -> 2:00 AM CET (clocks fall back)
+        var tz = TZConvert.GetTimeZoneInfo("Central European Standard Time");
+
+        // Start at 2:59:58 AM CEST (just before the transition)
+        var startTime = new DateTimeOffset(2023, 10, 29, 0, 59, 58, TimeSpan.Zero); // UTC
+
+        var trigger = TriggerBuilder.Create()
+            .WithIdentity("trigger1", "group1")
+            .WithSchedule(CronScheduleBuilder.CronSchedule("* * * ? * * *") // Every second
+                .InTimeZone(tz))
+            .StartAt(startTime)
+            .ForJob("job1", "group1")
+            .Build();
+
+        var nextFireTimes = TriggerUtils.ComputeFireTimes((IOperableTrigger)trigger, null, 10);
+
+        Assert.Multiple(() =>
+        {
+            // Verify strict monotonic increase in UTC
+            for (int i = 1; i < nextFireTimes.Count; i++)
+            {
+                var diff = (nextFireTimes[i] - nextFireTimes[i - 1]).TotalSeconds;
+                Assert.That(diff, Is.EqualTo(1.0).Within(0.001),
+                    $"Each fire should be 1 second after previous: [{i - 1}]={nextFireTimes[i - 1]:HH:mm:ss} -> [{i}]={nextFireTimes[i]:HH:mm:ss}");
+            }
+
+            // Verify no time goes backwards
+            for (int i = 1; i < nextFireTimes.Count; i++)
+            {
+                Assert.That(nextFireTimes[i].UtcDateTime, Is.GreaterThan(nextFireTimes[i - 1].UtcDateTime));
+            }
+        });
     }
 }

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -1576,6 +1576,11 @@ public class CronExpression : IDeserializationCallback, ISerializable
         }
     }
 
+    public virtual DateTimeOffset? GetTimeAt(DateTimeOffset afterTimeUtc)
+    {
+        return GetTimeAfter(afterTimeUtc, 0);
+    }
+
     /// <summary>
     /// Gets the next fire time after the given time.
     /// </summary>
@@ -1583,9 +1588,24 @@ public class CronExpression : IDeserializationCallback, ISerializable
     /// <returns></returns>
     public virtual DateTimeOffset? GetTimeAfter(DateTimeOffset afterTimeUtc)
     {
+        return GetTimeAfter(afterTimeUtc, 1);
+    }
+
+    /// <summary>
+    /// Gets the next fire time after the given time.
+    /// </summary>
+    /// <param name="afterTimeUtc">The UTC time to start searching from.</param>
+    /// <param name="afterOffsetInSeconds">Number of seconds to add before searching. Typically 1 second to find the next time "after" the given time.</param>
+    /// <returns></returns>
+    public virtual DateTimeOffset? GetTimeAfter(DateTimeOffset afterTimeUtc, int afterOffsetInSeconds)
+    {
+        // Store the original input time for validation at the end
+        DateTimeOffset originalAfterTime = afterTimeUtc;
+
         // move ahead one second, since we're computing the time *after* the
         // given time
-        afterTimeUtc = afterTimeUtc.AddSeconds(1);
+        if (afterOffsetInSeconds != 0)
+            afterTimeUtc = afterTimeUtc.AddSeconds(afterOffsetInSeconds);
 
         // CronTrigger does not deal with milliseconds
         DateTimeOffset d = CreateDateTimeWithoutMillis(afterTimeUtc);
@@ -2077,7 +2097,52 @@ public class CronExpression : IDeserializationCallback, ISerializable
             gotOne = true;
         } // while( !done )
 
-        return d.ToUniversalTime();
+        DateTimeOffset result = d.ToUniversalTime();
+
+        // Protect against ambiguous DST times causing backwards time travel
+        // During DST fall-back transitions, a local time like "2:00 AM" occurs twice.
+        // GetUtcOffset may pick the first occurrence (DST offset) even when we started
+        // after that point. If this happens, the result will be earlier than our input.
+        // We detect this and adjust to use the standard time offset instead.
+        if (result < originalAfterTime)
+        {
+            // We've hit an ambiguous time that resolved to the earlier (DST) occurrence.
+            // The time zone likely picked the DST offset when it should have picked standard time offset.
+            // Check if this local time is ambiguous in the time zone.
+            if (TimeZone.IsAmbiguousTime(d.DateTime))
+            {
+                // Get both possible UTC offsets for this ambiguous local time
+                var offsets = TimeZone.GetAmbiguousTimeOffsets(d.DateTime);
+
+                // Try both offsets and pick the one that gives us a time >= originalAfterTime
+                DateTimeOffset? validResult = null;
+                foreach (var offset in offsets)
+                {
+                    var candidate = new DateTimeOffset(d.DateTime, offset).ToUniversalTime();
+                    if (candidate >= originalAfterTime)
+                    {
+                        validResult = candidate;
+                        break;
+                    }
+                }
+
+                if (validResult.HasValue)
+                {
+                    return validResult.Value;
+                }
+
+                // Neither offset works - skip past the ambiguous period
+                // Find the end of the ambiguous period by adding 2 hours to result and searching
+                return GetTimeAfter(originalAfterTime.AddHours(2), 0);
+            }
+            else
+            {
+                // Not ambiguous but still going backwards - this shouldn't happen, but skip ahead to be safe
+                return GetTimeAfter(originalAfterTime.AddHours(1), 0);
+            }
+        }
+
+        return result;
     }
 
     /// <summary>

--- a/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
@@ -588,9 +588,10 @@ public class CronTriggerImpl : AbstractTrigger, ICronTrigger
             afterTimeUtc = SystemTime.UtcNow();
         }
 
-        if (StartTimeUtc > afterTimeUtc.Value)
+        // Ensure we don't search before the trigger's start time
+        if (afterTimeUtc.Value < StartTimeUtc)
         {
-            afterTimeUtc = startTimeUtc.AddSeconds(-1);
+            afterTimeUtc = StartTimeUtc;
         }
 
         if (EndTimeUtc.HasValue && afterTimeUtc.Value.CompareTo(EndTimeUtc.Value) >= 0)
@@ -599,6 +600,40 @@ public class CronTriggerImpl : AbstractTrigger, ICronTrigger
         }
 
         DateTimeOffset? pot = GetTimeAfter(afterTimeUtc.Value);
+        if (EndTimeUtc.HasValue && pot.HasValue && pot.Value > EndTimeUtc.Value)
+        {
+            return null;
+        }
+
+        return pot;
+    }
+        
+    /// <summary>
+    /// Returns the next time at which the <see cref="ITrigger" /> will fire, at or after the given time.
+    /// If the trigger does not fire at or after the given time, <see langword="null" /> will be returned.
+    /// </summary>
+    /// <param name="afterTimeUtc">The time to check for the next fire time after.</param>
+    /// <returns>The next fire time at or after the given time, or <see langword="null" />
+    /// if the trigger will not fire at or after the given time.</returns>
+    public DateTimeOffset? GetFireTimeAtOrAfter(DateTimeOffset? afterTimeUtc)
+    {
+        if (!afterTimeUtc.HasValue)
+        {
+            afterTimeUtc = SystemTime.UtcNow();
+        }
+
+        // Ensure we don't search before the trigger's start time
+        if (afterTimeUtc.Value < StartTimeUtc)
+        {
+            afterTimeUtc = StartTimeUtc;
+        }
+
+        if (EndTimeUtc.HasValue && afterTimeUtc.Value.CompareTo(EndTimeUtc.Value) > 0)
+        {
+            return null;
+        }
+
+        var pot = GetTimeAtOrAfter(afterTimeUtc.Value);
         if (EndTimeUtc.HasValue && pot.HasValue && pot.Value > EndTimeUtc.Value)
         {
             return null;
@@ -887,7 +922,7 @@ public class CronTriggerImpl : AbstractTrigger, ICronTrigger
     /// </returns>
     public override DateTimeOffset? ComputeFirstFireTimeUtc(ICalendar? cal)
     {
-        nextFireTimeUtc = GetFireTimeAfter(startTimeUtc.AddSeconds(-1));
+            nextFireTimeUtc = GetFireTimeAtOrAfter(startTimeUtc);
 
         while (nextFireTimeUtc.HasValue && cal != null && !cal.IsTimeIncluded(nextFireTimeUtc.Value))
         {
@@ -921,6 +956,16 @@ public class CronTriggerImpl : AbstractTrigger, ICronTrigger
     {
         return cronEx?.GetTimeAfter(afterTime);
     }
+        
+        /// <summary>
+        /// Gets the next valid time to fire at or after the given time.
+        /// </summary>
+        /// <param name="afterTime">The time to compute from.</param>
+        /// <returns>The next time to fire at or after the given time, or null if there is no such time.</returns>
+        protected DateTimeOffset? GetTimeAtOrAfter(DateTimeOffset afterTime)
+        {
+            return cronEx?.GetTimeAfter(afterTime,0);
+        }
 
     /// <summary>
     /// Returns the time before the given time that this <see cref="ICronTrigger" /> will fire.


### PR DESCRIPTION
  ## Problem
  When starting a cron trigger during the second occurrence of an ambiguous
  hour (after DST→ST transition), the scheduler would go backwards in time,
  causing infinite trigger loops. This occurred because GetTimeAfter() would
  find the first (DST) occurrence of an ambiguous local time instead of
  respecting that execution had already moved past that point.

  Example:
  - Start: 2023-10-29 02:00:00 +01:00 (01:00 UTC, second occurrence)
  - Bug: First fire time computed as 00:00 UTC (first occurrence)
  - Result: Infinite loop firing at times before the start time

  ## Solution
  Added backwards-time-travel protection in CronExpression.GetTimeAfter():
  - Store original input time before any modifications
  - After computing next fire time, verify result >= original input
  - If backwards movement detected and time is ambiguous:
    - Try all possible UTC offsets for the ambiguous local time
    - Select the offset that gives a valid forward-moving result
    - If no valid offset exists, skip past the ambiguous period
  - Ensures fundamental contract: GetTimeAfter(T) always returns time >= T

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Daylight Saving Time transition handling for scheduled jobs, ensuring proper fire-time calculation during DST changes including spring forward and fall back scenarios.

* **Tests**
  * Added comprehensive test coverage for DST edge cases, including handling of overlapping and missing hours during transitions and monotonic fire-time progression validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->