### PR TITLE
 Fix XML scheduling plugin to log errors and notify listeners on parsing failures

### DIFF
--- a/src/Quartz.Plugins/Plugin/Xml/XMLSchedulingDataProcessorPlugin.cs
+++ b/src/Quartz.Plugins/Plugin/Xml/XMLSchedulingDataProcessorPlugin.cs
@@ -275,6 +275,33 @@ public class XMLSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileScanListe
         return Task.CompletedTask;
     }
 
+    private async Task NotifySchedulerListenersOfError(
+        string message,
+        SchedulerException schedulerException,
+        CancellationToken cancellationToken = default)
+    {
+        // Get all registered scheduler listeners
+        var listeners = Scheduler.ListenerManager.GetSchedulerListeners();
+
+        // Notify each listener of the error
+        foreach (var listener in listeners)
+        {
+            try
+            {
+                await listener.SchedulerError(message, schedulerException, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            { 
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorException("Error while notifying SchedulerListener of error: ", ex);
+                Log.ErrorException("  Original error (for notification) was: " + message, schedulerException);
+            }
+        }
+    }
+
     private async Task ProcessFile(JobFile? jobFile, CancellationToken cancellationToken = default)
     {
         if (jobFile == null || jobFile.FileFound == false)
@@ -295,16 +322,25 @@ public class XMLSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileScanListe
                 Scheduler,
                 cancellationToken).ConfigureAwait(false);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        { 
+            throw;
+        }
         catch (Exception e)
         {
             var message = "Could not schedule jobs and triggers from file " + jobFile.FileName + ": " + e.Message;
+            var schedulerException = new SchedulerException(message, e);
+
+            // Always log the error
+            Log.ErrorException(message, e);
+
+            // Notify all scheduler listeners of the error
+            await NotifySchedulerListenersOfError(message, schedulerException, cancellationToken).ConfigureAwait(false);
+
+            // Decide whether to throw based on configuration
             if (FailOnSchedulingError)
             {
-                throw new SchedulerException(message, e);
-            }
-            else
-            {
-                Log.ErrorException(message, e);
+                throw schedulerException;
             }
         }
     }

--- a/src/Quartz.Tests.Unit/Plugin/Xml/XMLSchedulingDataProcessorPluginTest.cs
+++ b/src/Quartz.Tests.Unit/Plugin/Xml/XMLSchedulingDataProcessorPluginTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -75,5 +76,120 @@ public class XMLSchedulingDataProcessorPluginTest
 
         dataProcessor.FailOnSchedulingError = true;
         Assert.ThrowsAsync<SchedulerException>(async () => await dataProcessor.Start());
+    }
+
+    [Test]
+    public async Task ShouldLogErrorAndNotifyListenersForInvalidCronExpressionWithFailOnSchedulingErrorTrue()
+    {
+        // Arrange
+        var dataProcessor = new XMLSchedulingDataProcessorPlugin();
+        dataProcessor.FileNames = "./Xml/TestData/InvalidCronExpression.xml";
+        dataProcessor.FailOnSchedulingError = true;
+
+        var mockScheduler = A.Fake<IScheduler>();
+        var mockListenerManager = A.Fake<IListenerManager>();
+        var mockSchedulerListener = A.Fake<ISchedulerListener>();
+
+        A.CallTo(() => mockScheduler.ListenerManager).Returns(mockListenerManager);
+        A.CallTo(() => mockListenerManager.GetSchedulerListeners())
+            .Returns(new[] { mockSchedulerListener });
+
+        await dataProcessor.Initialize("testPlugin", mockScheduler);
+
+        // Act & Assert
+        var exception = Assert.ThrowsAsync<SchedulerException>(async () => await dataProcessor.Start());
+
+        // Verify that the error message contains helpful context
+        Assert.That(exception!.Message, Does.Contain("Could not schedule jobs and triggers from file"));
+        Assert.That(exception.Message, Does.Contain("InvalidCronExpression.xml"));
+
+        // Verify that SchedulerListener.SchedulerError was called
+        A.CallTo(() => mockSchedulerListener.SchedulerError(
+                A<string>.That.Contains("Could not schedule jobs and triggers from file"),
+                A<SchedulerException>._,
+                A<System.Threading.CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public async Task ShouldLogErrorAndNotifyListenersForInvalidCronExpressionWithFailOnSchedulingErrorFalse()
+    {
+        // Arrange
+        var dataProcessor = new XMLSchedulingDataProcessorPlugin();
+        dataProcessor.FileNames = "./Xml/TestData/InvalidCronExpression.xml";
+        dataProcessor.FailOnSchedulingError = false;
+
+        var mockScheduler = A.Fake<IScheduler>();
+        var mockListenerManager = A.Fake<IListenerManager>();
+        var mockSchedulerListener = A.Fake<ISchedulerListener>();
+
+        A.CallTo(() => mockScheduler.ListenerManager).Returns(mockListenerManager);
+        A.CallTo(() => mockListenerManager.GetSchedulerListeners())
+            .Returns(new[] { mockSchedulerListener });
+
+        await dataProcessor.Initialize("testPlugin", mockScheduler);
+
+        // Act - should NOT throw
+        await dataProcessor.Start();
+
+        // Verify that SchedulerListener.SchedulerError was called even when not throwing
+        A.CallTo(() => mockSchedulerListener.SchedulerError(
+                A<string>.That.Contains("Could not schedule jobs and triggers from file"),
+                A<SchedulerException>._,
+                A<System.Threading.CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public async Task ShouldContinueNotifyingListenersWhenOneListenerThrows()
+    {
+        // Arrange
+        var dataProcessor = new XMLSchedulingDataProcessorPlugin();
+        dataProcessor.FileNames = "./Xml/TestData/InvalidCronExpression.xml";
+        dataProcessor.FailOnSchedulingError = false;
+
+        var mockScheduler = A.Fake<IScheduler>();
+        var mockListenerManager = A.Fake<IListenerManager>();
+
+        // Create three listeners: one that throws, and two that succeed
+        var throwingListener = A.Fake<ISchedulerListener>();
+        var successListener1 = A.Fake<ISchedulerListener>();
+        var successListener2 = A.Fake<ISchedulerListener>();
+
+        // Configure the throwing listener to throw when SchedulerError is called
+        A.CallTo(() => throwingListener.SchedulerError(
+                A<string>._,
+                A<SchedulerException>._,
+                A<System.Threading.CancellationToken>._))
+            .Throws(new Exception("Listener failed to process error"));
+
+        A.CallTo(() => mockScheduler.ListenerManager).Returns(mockListenerManager);
+        A.CallTo(() => mockListenerManager.GetSchedulerListeners())
+            .Returns(new[] { throwingListener, successListener1, successListener2 });
+
+        await dataProcessor.Initialize("testPlugin", mockScheduler);
+
+        // Act - should NOT throw even though one listener throws
+        await dataProcessor.Start();
+
+        // Assert - verify that all listeners had SchedulerError called, including the throwing one
+        A.CallTo(() => throwingListener.SchedulerError(
+                A<string>.That.Contains("Could not schedule jobs and triggers from file"),
+                A<SchedulerException>._,
+                A<System.Threading.CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+
+        // Verify that the non-throwing listeners were still notified despite the first one throwing
+        A.CallTo(() => successListener1.SchedulerError(
+                A<string>.That.Contains("Could not schedule jobs and triggers from file"),
+                A<SchedulerException>._,
+                A<System.Threading.CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+
+        A.CallTo(() => successListener2.SchedulerError(
+                A<string>.That.Contains("Could not schedule jobs and triggers from file"),
+                A<SchedulerException>._,
+                A<System.Threading.CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
     }
 }

--- a/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
+++ b/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
@@ -14,6 +14,9 @@
     <Content Include="Xml\TestData\JobTypeNotFound.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Xml\TestData\InvalidCronExpression.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Serialized\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/Quartz.Tests.Unit/Xml/TestData/InvalidCronExpression.xml
+++ b/src/Quartz.Tests.Unit/Xml/TestData/InvalidCronExpression.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<job-scheduling-data xmlns="http://quartznet.sourceforge.net/JobSchedulingData" version="2.0">
+
+  <schedule>
+    <job>
+      <name>JobName</name>
+      <group>TestGroup</group>
+      <job-type>Quartz.Job.NoOpJob, Quartz</job-type>
+    </job>
+
+    <trigger>
+      <cron>
+        <name>TriggerName</name>
+        <group>TestGroup</group>
+        <job-name>JobName</job-name>
+        <job-group>TestGroup</job-group>
+        <!-- Invalid: missing seconds field, only has 5 fields instead of 6 -->
+        <cron-expression>0 * * * *</cron-expression>
+      </cron>
+    </trigger>
+  </schedule>
+
+</job-scheduling-data>


### PR DESCRIPTION
 Fix XML scheduling plugin to log errors and notify listeners on parsing failures

  When XMLSchedulingDataProcessorPlugin encounters invalid cron expressions or
  other scheduling errors, it now:
  - Always logs the error details via Log.ErrorException()
  - Notifies all registered SchedulerListener instances via SchedulerError()
  - Then throws SchedulerException if FailOnSchedulingError=true (or continues if false)

  Previously with FailOnSchedulingError=true, exceptions were thrown immediately
  without logging or listener notification, causing silent failures where the last
  log message was "Parsing XML file:" with no additional error information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for XML scheduling configuration files. Errors are now logged and listeners are notified when scheduling configuration issues are detected. Error behavior is configurable to either fail immediately or continue execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->