### PR TITLE
Fix GetScheduler(name) returning null before default scheduler initalization

### DIFF
--- a/src/Quartz.Extensions.DependencyInjection/ServiceCollectionSchedulerFactory.cs
+++ b/src/Quartz.Extensions.DependencyInjection/ServiceCollectionSchedulerFactory.cs
@@ -35,7 +35,27 @@ internal sealed class ServiceCollectionSchedulerFactory : StdSchedulerFactory
         this.processor = processor;
     }
 
-    public override async Task<IScheduler> GetScheduler(CancellationToken cancellationToken = default)
+    public override Task<IScheduler> GetScheduler(CancellationToken cancellationToken = default)
+    {
+        return EnsureSchedulerCreated(cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets a scheduler by name, ensuring it is created and initialized first.
+    /// </summary>
+    /// <param name="schedName">Name of the scheduler to retrieve</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The scheduler with the given name, or null if not found</returns>    
+    public override async Task<IScheduler?> GetScheduler(string schedName, CancellationToken cancellationToken = default)
+    {
+        // Ensure the default scheduler is created and initialized
+        await EnsureSchedulerCreated(cancellationToken);
+
+        // Now perform the lookup by name
+        return await base.GetScheduler(schedName, cancellationToken);
+    }
+
+    private async Task<IScheduler> EnsureSchedulerCreated(CancellationToken cancellationToken)
     {
         await semaphore.WaitAsync(cancellationToken);
         try
@@ -51,13 +71,11 @@ internal sealed class ServiceCollectionSchedulerFactory : StdSchedulerFactory
             var scheduler = await base.GetScheduler(cancellationToken);
 
             // The base method may produce a new scheduler in the event that the original scheduler was stopped
-            if (ReferenceEquals(scheduler, initializedScheduler))
+            if (!ReferenceEquals(scheduler, initializedScheduler))
             {
-                return scheduler;
+                await InitializeScheduler(scheduler, cancellationToken);
+                initializedScheduler = scheduler;
             }
-
-            await InitializeScheduler(scheduler, cancellationToken);
-            initializedScheduler = scheduler;
 
             return scheduler;
         }

--- a/src/Quartz.Tests.Unit/Extensions/DependencyInjection/ServiceCollectionExtensionsTests.cs
+++ b/src/Quartz.Tests.Unit/Extensions/DependencyInjection/ServiceCollectionExtensionsTests.cs
@@ -5,10 +5,12 @@ using System.Threading.Tasks;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NUnit.Framework;
 
 using Quartz.Impl.AdoJobStore.Common;
+using Quartz.Logging;
 using Quartz.Util;
 
 namespace Quartz.Tests.Unit.Extensions.DependencyInjection;
@@ -457,6 +459,77 @@ public class ServiceCollectionExtensionsTests
         Assert.That(quartzOptions[$"quartz.dataSource.{SchedulerBuilder.AdoProviderOptions.DefaultDataSourceName}.connectionProvider.type"], Is.EqualTo(typeof(DataSourceDbProvider).AssemblyQualifiedNameWithoutVersion()));
     }
 #endif
+
+    [Test]
+    public async Task GetScheduler_ByName_ShouldReturnSchedulerWithoutRequiringDefaultSchedulerCall()
+    {
+        // This tests the fix for the issue where GetScheduler(name) returned null
+        // unless GetScheduler() was called first
+        const string schedulerName = "TestScheduler";
+
+        try
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddQuartz(q =>
+            {
+                q.SchedulerName = schedulerName;
+                q.UseInMemoryStore();
+            });
+
+            await using var serviceProvider = services.BuildServiceProvider();
+            var factory = serviceProvider.GetRequiredService<ISchedulerFactory>();
+
+            // Call GetScheduler with the name directly, without calling GetScheduler() first
+            var scheduler = await factory.GetScheduler(schedulerName);
+
+            // Should not be null
+            Assert.That(scheduler, Is.Not.Null);
+            Assert.That(scheduler.SchedulerName, Is.EqualTo(schedulerName));
+
+            await scheduler.Shutdown();
+        }
+        finally
+        {
+            LogProvider.SetCurrentLogProvider(null);
+        }
+    }
+
+    [Test]
+    public async Task GetScheduler_ByName_AfterDefaultCall_ShouldReturnSameScheduler()
+    {
+        // This tests that both methods return the same scheduler instance
+        const string schedulerName = "TestScheduler2";
+
+        try
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddQuartz(q =>
+            {
+                q.SchedulerName = schedulerName;
+                q.UseInMemoryStore();
+            });
+
+            var serviceProvider = services.BuildServiceProvider();
+            var factory = serviceProvider.GetRequiredService<ISchedulerFactory>();
+
+            // Call both methods
+            var defaultScheduler = await factory.GetScheduler();
+            var namedScheduler = await factory.GetScheduler(schedulerName);
+
+            // Should return the same instance
+            Assert.That(namedScheduler, Is.Not.Null);
+            Assert.That(namedScheduler, Is.SameAs(defaultScheduler));
+            Assert.That(namedScheduler.SchedulerName, Is.EqualTo(schedulerName));
+
+            await defaultScheduler.Shutdown();
+        }
+        finally
+        {
+            LogProvider.SetCurrentLogProvider(null);
+        }
+    }
 
     private sealed class DummyJob : IJob
     {


### PR DESCRIPTION
ServiceCollectionSchedulerFactory now properly ensures the scheduler is created and initialized before any lookup operations. Previously, calling GetScheduler(schedulerName) would return null unless GetScheduler() was called first, because the named method only performed a repository lookup without triggering scheduler creation.

Changes:
- Extracted scheduler creation logic into private EnsureSchedulerCreated() method
- Both GetScheduler() and GetScheduler(string) now use this shared implementation
- This ensures initialization happens consistently regardless of which method is called first

Relates to #2786

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduler initialization logic to ensure consistent behavior when retrieving named schedulers.

* **Tests**
  * Added test coverage for named scheduler retrieval to validate correct scheduler instance handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->